### PR TITLE
add getScheduledTasks and cancelScheduledTask tools

### DIFF
--- a/src/tools.ts
+++ b/src/tools.ts
@@ -68,6 +68,56 @@ const scheduleTask = tool({
     return `Task scheduled for type "${when.type}" : ${input}`;
   },
 });
+
+/**
+ * Tool to list all scheduled tasks
+ * This executes automatically without requiring human confirmation
+ */
+const getScheduledTasks = tool({
+  description: "List all tasks that have been scheduled",
+  parameters: z.object({}),
+  execute: async () => {
+    const agent = agentContext.getStore();
+    if (!agent) {
+      throw new Error("No agent found");
+    }
+    try {
+      const tasks = agent.getSchedules();
+      if (!tasks || tasks.length === 0) {
+        return "No scheduled tasks found.";
+      }
+      return tasks.map((task) => `[${task.id}] ${task.payload}`).join("\n");
+    } catch (error) {
+      console.error("Error listing scheduled tasks", error);
+      return `Error listing scheduled tasks: ${error}`;
+    }
+  },
+});
+
+/**
+ * Tool to cancel a scheduled task by its ID
+ * This executes automatically without requiring human confirmation
+ */
+const cancelScheduledTask = tool({
+  description: "Cancel a scheduled task using its ID",
+  parameters: z.object({
+    taskId: z.string().describe("The ID of the task to cancel"),
+  }),
+  execute: async ({ taskId }) => {
+    const agent = agentContext.getStore();
+    if (!agent) {
+      throw new Error("No agent found");
+    }
+    try {
+      await agent.cancelSchedule(taskId);
+      return `Task ${taskId} has been successfully canceled.`;
+    } catch (error) {
+      console.error("Error canceling scheduled task", error);
+      return `Error canceling task ${taskId}: ${error}`;
+    }
+  },
+});
+
 /**
  * Export all available tools
  * These will be provided to the AI model to describe available capabilities
@@ -76,6 +126,8 @@ export const tools = {
   getWeatherInformation,
   getLocalTime,
   scheduleTask,
+  getScheduledTasks,
+  cancelScheduledTask,
 };
 
 /**


### PR DESCRIPTION
### TL;DR

Added two new tools for managing scheduled tasks: one to list all scheduled tasks and another to cancel specific tasks by ID.

### What changed?

- Added `getScheduledTasks` tool that retrieves and displays all scheduled tasks
- Added `cancelScheduledTask` tool that allows cancellation of a specific task by its ID
- Both tools are designed to execute automatically without requiring human confirmation
- Updated the exported `tools` object to include these new functions

### How to test?

1. Schedule a task using the existing `scheduleTask` tool
2. Use the new `getScheduledTasks` tool to verify the task appears in the list
3. Note the task ID from the list output (format: `[id] task description`)
4. Use the new `cancelScheduledTask` tool with the noted ID
5. Verify the cancellation was successful by listing tasks again

### Why make this change?

These tools complete the task scheduling lifecycle by providing the ability to view and manage scheduled tasks. Without these capabilities, users had no way to see what tasks were pending or cancel them if needed, making the scheduling feature incomplete.